### PR TITLE
Deleted explicit access modifiers in custom interfaces, because inter…

### DIFF
--- a/TeamWebApplication/Controllers/CourseController.cs
+++ b/TeamWebApplication/Controllers/CourseController.cs
@@ -19,16 +19,16 @@ namespace TeamWebApplication.Controllers
 
         public IActionResult Index()
         {
-			_userContainer.currentCourseId = 0;
+			_userContainer.CurrentCourseId = 0;
 			IEnumerable<Course> coursesTaken = (
                 from user in _userContainer.userList
-                where user.UserId == _userContainer.loggedInUserId
+                where user.UserId == _userContainer.LoggedInUserId
                 from courseId in user.CoursesUserTakesId
-                join course in _courseContainer.courseList on courseId equals course.Id
+                join course in _courseContainer.CourseList on courseId equals course.Id
                 select course
             ).ToList();
             
-            User currentUser = _userContainer.GetUser(_userContainer.loggedInUserId);
+            User currentUser = _userContainer.GetUser(_userContainer.LoggedInUserId);
 
             var viewModel = new CourseViewModel
             {
@@ -48,9 +48,9 @@ namespace TeamWebApplication.Controllers
         [HttpPost]
         public IActionResult Create(Course course)
         {
-            int createdCourseId = _courseContainer.CreateCourse(course, _userContainer.loggedInUserId);
-            _userContainer.AddRelation(_userContainer.loggedInUserId, createdCourseId);
-            _relationContainer.AddRelationData(createdCourseId, _userContainer.loggedInUserId);
+            int createdCourseId = _courseContainer.CreateCourse(course, _userContainer.LoggedInUserId);
+            _userContainer.AddRelation(_userContainer.LoggedInUserId, createdCourseId);
+            _relationContainer.AddRelationData(createdCourseId, _userContainer.LoggedInUserId);
             _courseContainer.WriteCourses();
             return RedirectToAction("Index");
         }
@@ -75,28 +75,28 @@ namespace TeamWebApplication.Controllers
 
         public IActionResult Delete(int courseId)
         {
-            Course course = _courseContainer.courseList.SingleOrDefault(course => course.Id == courseId);
+            Course course = _courseContainer.CourseList.SingleOrDefault(course => course.Id == courseId);
             return View(course);
         }
 
         [HttpPost, ActionName("Delete")]
         public IActionResult DeleteCourse(int courseId)
         {
-            Course course = _courseContainer.courseList.SingleOrDefault(course => course.Id == courseId);
+            Course course = _courseContainer.CourseList.SingleOrDefault(course => course.Id == courseId);
             if (course == null)
             {
                 return NotFound();
             }
             _courseContainer.DeleteCourse(course);
-            _userContainer.DeleteRelation(_userContainer.loggedInUserId, courseId);
-            _relationContainer.DeleteRelationData(courseId, _userContainer.loggedInUserId);
+            _userContainer.DeleteRelation(_userContainer.LoggedInUserId, courseId);
+            _relationContainer.DeleteRelationData(courseId, _userContainer.LoggedInUserId);
             _courseContainer.WriteCourses();
             return RedirectToAction("Index");
         }
 
         public IActionResult AddUser(int courseId)
         {
-            _userContainer.currentCourseId = courseId;
+            _userContainer.CurrentCourseId = courseId;
             return View();
         }
 
@@ -104,17 +104,17 @@ namespace TeamWebApplication.Controllers
         public IActionResult AddUser(String userIdString)
         {
             String[] userIdList = userIdString.Split(';');
-            Course? currentCourse = _courseContainer.GetCourse(_userContainer.currentCourseId);
+            Course? currentCourse = _courseContainer.GetCourse(_userContainer.CurrentCourseId);
             foreach (var word in userIdList)
             {
                 if (Int32.TryParse(word, out int userId) != false && currentCourse != null)
                 {
                     User? user;
-                    if ((user = _userContainer.GetUser(userId)) != null && userId != _userContainer.loggedInUserId)
+                    if ((user = _userContainer.GetUser(userId)) != null && userId != _userContainer.LoggedInUserId)
                     {
-                        _relationContainer.AddRelationData(_userContainer.currentCourseId, userId);
+                        _relationContainer.AddRelationData(_userContainer.CurrentCourseId, userId);
                         currentCourse.UsersInCourseId.Add(userId);
-                        user.CoursesUserTakesId.Add(_userContainer.currentCourseId);
+                        user.CoursesUserTakesId.Add(_userContainer.CurrentCourseId);
                     }
                 }
             }
@@ -123,7 +123,7 @@ namespace TeamWebApplication.Controllers
 
         public IActionResult RemoveUser(int courseId)
         {
-            _userContainer.currentCourseId = courseId;
+            _userContainer.CurrentCourseId = courseId;
             return View();
         }
 
@@ -131,17 +131,17 @@ namespace TeamWebApplication.Controllers
         public IActionResult RemoveUser(String userIdString)
         {
             String[] userIdList = userIdString.Split(';');
-            Course? currentCourse = _courseContainer.GetCourse(_userContainer.currentCourseId);
+            Course? currentCourse = _courseContainer.GetCourse(_userContainer.CurrentCourseId);
             foreach (var word in userIdList)
             {
                 if (Int32.TryParse(word, out int userId) != false && currentCourse != null)
                 {
                     User? user;
-                    if ((user = _userContainer.GetUser(userId)) != null && userId != _userContainer.loggedInUserId)
+                    if ((user = _userContainer.GetUser(userId)) != null && userId != _userContainer.LoggedInUserId)
                     {
-                        _relationContainer.RemoveRelationData(_userContainer.currentCourseId, userId);
+                        _relationContainer.RemoveRelationData(_userContainer.CurrentCourseId, userId);
                         currentCourse.UsersInCourseId.Remove(userId);
-                        user.CoursesUserTakesId.Remove(_userContainer.currentCourseId);
+                        user.CoursesUserTakesId.Remove(_userContainer.CurrentCourseId);
                     }
                 }
             }
@@ -150,8 +150,8 @@ namespace TeamWebApplication.Controllers
 
         public IActionResult CheckUsers(int courseId)
         {
-            _userContainer.currentCourseId = courseId;
-            Course? currentCourse = _courseContainer.GetCourse(_userContainer.currentCourseId);
+            _userContainer.CurrentCourseId = courseId;
+            Course? currentCourse = _courseContainer.GetCourse(_userContainer.CurrentCourseId);
             ICollection<User> userInCourseList = (
                 from user in _userContainer.userList
                 where currentCourse.UsersInCourseId.Contains(user.UserId)

--- a/TeamWebApplication/Controllers/CourseEnvironmentController.cs
+++ b/TeamWebApplication/Controllers/CourseEnvironmentController.cs
@@ -21,7 +21,7 @@ namespace TeamWebApplication.Controllers
 
         public IActionResult Index(int courseId)
         {
-			_userContainer.currentCourseId = courseId;
+			_userContainer.CurrentCourseId = courseId;
 			IEnumerable<Post> coursePosts = (
                 from post in _postContainer.PostList
                 where post.CourseId == courseId
@@ -36,9 +36,9 @@ namespace TeamWebApplication.Controllers
                 select comment
             ).ToList();
             comment1.CourseId = courseId;
-            int loggedInUser = _userContainer.loggedInUserId;
+            int loggedInUser = _userContainer.LoggedInUserId;
 
-            User currentUser = _userContainer.GetUser(_userContainer.loggedInUserId);
+            User currentUser = _userContainer.GetUser(_userContainer.LoggedInUserId);
 
             var viewModel = new CourseAndComment
             {
@@ -53,7 +53,7 @@ namespace TeamWebApplication.Controllers
 
         public IActionResult TeacherVisitorIndex(int courseId)
         {
-            _userContainer.currentCourseId = courseId;
+            _userContainer.CurrentCourseId = courseId;
             IEnumerable<Post> coursePosts = (
                 from post in _postContainer.PostList
                 where post.CourseId == courseId
@@ -68,9 +68,9 @@ namespace TeamWebApplication.Controllers
                 select comment
             ).ToList();
             comment1.CourseId = courseId;
-            int loggedInUser = _userContainer.loggedInUserId;
+            int loggedInUser = _userContainer.LoggedInUserId;
 
-            User currentUser = _userContainer.GetUser(_userContainer.loggedInUserId);
+            User currentUser = _userContainer.GetUser(_userContainer.LoggedInUserId);
 
             var viewModel = new CourseAndComment
             {
@@ -86,7 +86,7 @@ namespace TeamWebApplication.Controllers
         [HttpPost]
         public IActionResult AddComment(int courseId, Comment comment)
         {
-            _commentContainer.CreateComment(comment, courseId, _userContainer.loggedInUserId, _userContainer);
+            _commentContainer.CreateComment(comment, courseId, _userContainer.LoggedInUserId, _userContainer);
             return RedirectToAction("Index", new { courseId });
         }
 
@@ -111,14 +111,14 @@ namespace TeamWebApplication.Controllers
         public IActionResult CreateTextPost()
         {
             Post post = new TextPost();
-            post.CourseId = _userContainer.currentCourseId;
+            post.CourseId = _userContainer.CurrentCourseId;
             return View(post);
         }
 
         public IActionResult CreateLinkPost()
         {
             Post post = new LinkPost();
-            post.CourseId = _userContainer.currentCourseId;
+            post.CourseId = _userContainer.CurrentCourseId;
             return View(post);
         }
 
@@ -126,7 +126,7 @@ namespace TeamWebApplication.Controllers
         public IActionResult CreateTextPost(TextPost post, int courseId)
         {
             post.PostType = PostType.Text;
-            _postContainer.CreatePost(post, _userContainer.currentCourseId);
+            _postContainer.CreatePost(post, _userContainer.CurrentCourseId);
             _postContainer.WritePosts();
             return RedirectToAction("Index", new { courseId });
         }
@@ -135,7 +135,7 @@ namespace TeamWebApplication.Controllers
         public IActionResult CreateLinkPost(LinkPost post, int courseId)
         {
             post.PostType = PostType.Link;
-			_postContainer.CreatePost(post, _userContainer.currentCourseId);
+			_postContainer.CreatePost(post, _userContainer.CurrentCourseId);
 			_postContainer.WritePosts();
             return RedirectToAction("Index", new { courseId });
         }

--- a/TeamWebApplication/Controllers/HomeController.cs
+++ b/TeamWebApplication/Controllers/HomeController.cs
@@ -18,8 +18,8 @@ namespace TeamWebApplication.Controllers
 
         public IActionResult Index()
         {
-            _userContainer.loggedInUserId = 0;
-            _userContainer.loggedInUserRole = null;
+            _userContainer.LoggedInUserId = 0;
+            _userContainer.LoggedInUserRole = null;
             return View();
         }
 

--- a/TeamWebApplication/Controllers/LogInController.cs
+++ b/TeamWebApplication/Controllers/LogInController.cs
@@ -31,8 +31,8 @@ namespace TeamWebApplication.Controllers
             var user = _userContainer.userList.SingleOrDefault(user => user.Password == login.Password && user.UserId == login.UserId);
 			if (user == null)
                 return RedirectToAction("Index", "Login");//user was not found}
-            _userContainer.loggedInUserId = user.UserId;
-            _userContainer.loggedInUserRole = user.Role;
+            _userContainer.LoggedInUserId = user.UserId;
+            _userContainer.LoggedInUserRole = user.Role;
              return RedirectToAction("Index", "Course");
         }
     }

--- a/TeamWebApplication/Controllers/PublicCourseController.cs
+++ b/TeamWebApplication/Controllers/PublicCourseController.cs
@@ -18,11 +18,11 @@ namespace TeamWebApplication.Controllers
         public IActionResult Index()
         {
             IEnumerable<Course> publicCourses = (
-                from course in _courseContainer.courseList
+                from course in _courseContainer.CourseList
                 where course.IsPublic == true
                 select course
             ).ToList();
-            User currentUser = _userContainer.GetUser(_userContainer.loggedInUserId);
+            User currentUser = _userContainer.GetUser(_userContainer.LoggedInUserId);
 
             var viewModel = new CourseViewModel
             {
@@ -36,7 +36,7 @@ namespace TeamWebApplication.Controllers
         public IActionResult TeacherIndex()
         {
             IEnumerable<Course> publicCourses = (
-                from course in _courseContainer.courseList
+                from course in _courseContainer.CourseList
                 where course.IsPublic == true
                 select course
             ).ToList();

--- a/TeamWebApplication/Data/Containers/CourseContainer.cs
+++ b/TeamWebApplication/Data/Containers/CourseContainer.cs
@@ -8,12 +8,12 @@ namespace TeamWebApplication.Data
     {
         public string FetchingPath { get; }
         private int courseIdCounter;
-        public ICollection<Course> courseList { get; }
+        public ICollection<Course> CourseList { get; }
 
         public CourseContainer(IRelationContainer relationContainer, string fetchingPath = "./TextData/CourseData.txt")
         {
             this.FetchingPath = fetchingPath;
-            courseList = new List<Course>();
+            CourseList = new List<Course>();
             FetchCourses(relationContainer);
         }
 
@@ -38,19 +38,19 @@ namespace TeamWebApplication.Data
                         IsVisible: Boolean.Parse(splitString[4]),                                                        
                         isPublic: Boolean.Parse(splitString[5])                                                           
                     );
-                    foreach (Relation<int> relation in relationContainer.relationData)
+                    foreach (Relation<int> relation in relationContainer.RelationData)
                     {
                         if (Int32.Parse(splitString[0]) == relation.Value1) //Course
                             course.UsersInCourseId.Add(relation.Value2); //User
                     }
-                    courseList.Add(course);
+                    CourseList.Add(course);
                 }
             }
         }
 
         public Course? GetCourse(int courseId)
         {
-            Course? course = courseList.SingleOrDefault(course => course.Id == courseId);
+            Course? course = CourseList.SingleOrDefault(course => course.Id == courseId);
             return course;
         }
 
@@ -60,7 +60,7 @@ namespace TeamWebApplication.Data
             courseIdCounter++;
             course.CreationDate = DateTime.Now;
             course.UsersInCourseId.Add(loggedInUserId);
-            courseList.Add(course);
+            CourseList.Add(course);
             return course.Id;
         }
 
@@ -69,20 +69,20 @@ namespace TeamWebApplication.Data
             using (StreamWriter? writer = new StreamWriter(FetchingPath))
             {
                 writer.WriteLine(courseIdCounter);
-                foreach (var course in courseList)
+                foreach (var course in CourseList)
                     writer.WriteLine(course.FormattedToString());
             }
         }
 
         public void PrintCourseList()
         {
-            foreach (var course in courseList)
+            foreach (var course in CourseList)
                 System.Diagnostics.Debug.WriteLine(course.FormattedToString());
         }
 
         public void PrintRelation()
         {
-            foreach (var course in courseList)
+            foreach (var course in CourseList)
             {
                 foreach (var relation in course.UsersInCourseId)
                     System.Diagnostics.Debug.WriteLine(relation);
@@ -90,7 +90,7 @@ namespace TeamWebApplication.Data
         }
         public int DeleteCourse(Course courseToRemove)
         {
-                courseList.Remove(courseToRemove);
+                CourseList.Remove(courseToRemove);
                 WriteCourses(); 
             return courseToRemove.Id;
         }

--- a/TeamWebApplication/Data/Containers/RelationContainer.cs
+++ b/TeamWebApplication/Data/Containers/RelationContainer.cs
@@ -4,12 +4,12 @@ namespace TeamWebApplication.Data
     public class RelationContainer : IRelationContainer
     {
         public string FetchingPath { get; }
-        public ICollection<Relation<int>> relationData { get; }
+        public ICollection<Relation<int>> RelationData { get; }
 
         public RelationContainer(string fetchingPath = "./TextData/UserCourseRelation.txt")
         {
             this.FetchingPath = fetchingPath;
-            relationData = new List<Relation<int>>();
+            RelationData = new List<Relation<int>>();
             FetchRelationData();
         }
 
@@ -23,30 +23,30 @@ namespace TeamWebApplication.Data
                 while ((readString = reader.ReadLine()) != null)
                 {
                     splitString = readString.Split(';');
-                    relationData.Add(new Relation<int>(Int32.Parse(splitString[0]), Int32.Parse(splitString[1]))); //Course, User
+                    RelationData.Add(new Relation<int>(Int32.Parse(splitString[0]), Int32.Parse(splitString[1]))); //Course, User
                 }
             }
         }
 
         public void AddRelationData(int courseId, int userId)
         { 
-            if (!relationData.Any(item => item.Value1 == courseId && item.Value2 == userId)) //Course, User
+            if (!RelationData.Any(item => item.Value1 == courseId && item.Value2 == userId)) //Course, User
             {
-                relationData.Add(new Relation<int>(courseId, userId));
+                RelationData.Add(new Relation<int>(courseId, userId));
                 WriteRelationData();
             }
         }
 
         public void RemoveRelationData(int courseId, int userId)
         {
-            relationData.Remove(new Relation<int>(courseId, userId));
+            RelationData.Remove(new Relation<int>(courseId, userId));
             WriteRelationData();
         }
 
         public void DeleteRelationData(int courseId, int userId)
         {
-            var relationToRemove = relationData.FirstOrDefault(relation => relation.Value1 == courseId && relation.Value2 == userId); //Course, User
-            relationData.Remove(relationToRemove);
+            var relationToRemove = RelationData.FirstOrDefault(relation => relation.Value1 == courseId && relation.Value2 == userId); //Course, User
+            RelationData.Remove(relationToRemove);
             WriteRelationData();
         }
 
@@ -54,14 +54,14 @@ namespace TeamWebApplication.Data
         {
             using (StreamWriter? writer = new StreamWriter(FetchingPath))
             {
-                foreach (var relation in relationData)
+                foreach (var relation in RelationData)
                     writer.WriteLine(relation.ToString());
             }
         }
 
         public void PrintRelationData()
         {
-            foreach (var relation in relationData)
+            foreach (var relation in RelationData)
                 System.Diagnostics.Debug.WriteLine(relation.ToString());
         }
     }

--- a/TeamWebApplication/Data/Containers/Unused/ContainerHelper.cs
+++ b/TeamWebApplication/Data/Containers/Unused/ContainerHelper.cs
@@ -23,7 +23,7 @@ namespace TeamWebApplication.Data.Containers.Unused
 
         public static void PrintRelationalList(ICourseContainer courseContainer, IUserContainer userContainer)
         {
-            foreach (var course in courseContainer.courseList)
+            foreach (var course in courseContainer.CourseList)
             {
                 System.Diagnostics.Debug.WriteLine(course.FormattedToString());
                 foreach (var inUser in course.UsersInCourseId)

--- a/TeamWebApplication/Data/Containers/UserContainer.cs
+++ b/TeamWebApplication/Data/Containers/UserContainer.cs
@@ -9,9 +9,9 @@ namespace TeamWebApplication.Data
     public class UserContainer : IUserContainer
     {
         public string FetchingPath { get; }
-        public int loggedInUserId { get; set; } = 0;
-        public Role? loggedInUserRole { get; set; } = null;
-        public int currentCourseId { get; set; } = 0;
+        public int LoggedInUserId { get; set; } = 0;
+        public Role? LoggedInUserRole { get; set; } = null;
+        public int CurrentCourseId { get; set; } = 0;
         private int userIdCounter;
         public ICollection<User> userList { get; }
 
@@ -44,7 +44,7 @@ namespace TeamWebApplication.Data
                         faculty: (Faculty)Enum.Parse(typeof(Faculty), splitString[6]),                          
                         specialization: (Specialization)Enum.Parse(typeof(Specialization), splitString[7])          
                         );
-                    foreach (Relation<int> relation in relationContainer.relationData)
+                    foreach (Relation<int> relation in relationContainer.RelationData)
                     {
                         if (Int32.Parse(splitString[0]) == relation.Value2) //User
                             user.CoursesUserTakesId.Add(relation.Value1); //Course

--- a/TeamWebApplication/Data/Interfaces/ICommentContainer.cs
+++ b/TeamWebApplication/Data/Interfaces/ICommentContainer.cs
@@ -8,7 +8,7 @@ namespace TeamWebApplication.Data
         void FetchComments();
         void PrintComments();
         void WriteComments();
-        void CreateComment(Comment comment, int currentCourseId, int loggedInUserId, IUserContainer _userContainer);
+        void CreateComment(Comment comment, int CurrentCourseId, int LoggedInUserId, IUserContainer _userContainer);
         void DeleteComment(Comment comment);
         ICollection<Comment> CommentList { get; }
     }

--- a/TeamWebApplication/Data/Interfaces/ICommentContainer.cs
+++ b/TeamWebApplication/Data/Interfaces/ICommentContainer.cs
@@ -8,7 +8,7 @@ namespace TeamWebApplication.Data
         void FetchComments();
         void PrintComments();
         void WriteComments();
-        void CreateComment(Comment comment, int CurrentCourseId, int LoggedInUserId, IUserContainer _userContainer);
+        void CreateComment(Comment comment, int currentCourseId, int loggedInUserId, IUserContainer _userContainer);
         void DeleteComment(Comment comment);
         ICollection<Comment> CommentList { get; }
     }

--- a/TeamWebApplication/Data/Interfaces/ICourseContainer.cs
+++ b/TeamWebApplication/Data/Interfaces/ICourseContainer.cs
@@ -5,12 +5,12 @@ namespace TeamWebApplication.Data
     public interface ICourseContainer
     {
         void FetchCourses(IRelationContainer relationContainer);
-        public Course? GetCourse(int courseId);
+        Course? GetCourse(int courseId);
         void PrintCourseList();
         void WriteCourses();
         int CreateCourse(Course course, int loggedInUserId);
-        public int DeleteCourse(Course courseToRemove);
-        public void PrintRelation();
-        ICollection<Course> courseList { get; }
+        int DeleteCourse(Course courseToRemove);
+        void PrintRelation();
+        ICollection<Course> CourseList { get; }
     }
 }

--- a/TeamWebApplication/Data/Interfaces/IPostContainer.cs
+++ b/TeamWebApplication/Data/Interfaces/IPostContainer.cs
@@ -8,8 +8,8 @@ namespace TeamWebApplication.Data
         void PrintPostList();
         void WritePosts();
         ICollection<Post> PostList { get; }
-        public int CreatePost(Post post, int currentCourseId);
-        public void DeletePost(Post post);
-        public Post? GetPost(int postId);
+        int CreatePost(Post post, int CurrentCourseId);
+        void DeletePost(Post post);
+        Post? GetPost(int postId);
     }
 }

--- a/TeamWebApplication/Data/Interfaces/IPostContainer.cs
+++ b/TeamWebApplication/Data/Interfaces/IPostContainer.cs
@@ -8,7 +8,7 @@ namespace TeamWebApplication.Data
         void PrintPostList();
         void WritePosts();
         ICollection<Post> PostList { get; }
-        int CreatePost(Post post, int CurrentCourseId);
+        int CreatePost(Post post, int currentCourseId);
         void DeletePost(Post post);
         Post? GetPost(int postId);
     }

--- a/TeamWebApplication/Data/Interfaces/IRelationContainer.cs
+++ b/TeamWebApplication/Data/Interfaces/IRelationContainer.cs
@@ -5,9 +5,9 @@
         void FetchRelationData();
         void PrintRelationData();
         void WriteRelationData();
-        public void AddRelationData(int courseId, int userId);
-        public void RemoveRelationData(int courseId, int userId);
-        public void DeleteRelationData(int courseId, int userId);
-        ICollection<Relation<int>> relationData { get; }
+        void AddRelationData(int courseId, int userId);
+        void RemoveRelationData(int courseId, int userId);
+        void DeleteRelationData(int courseId, int userId);
+        ICollection<Relation<int>> RelationData { get; }
     }
 }

--- a/TeamWebApplication/Data/Interfaces/IUserContainer.cs
+++ b/TeamWebApplication/Data/Interfaces/IUserContainer.cs
@@ -5,16 +5,16 @@ namespace TeamWebApplication.Data
     public interface IUserContainer
     {
         void FetchUsers(IRelationContainer relationContainer);
-        public User? GetUser(int userId);
+        User? GetUser(int userId);
         void PrintUserList();
         void WriteUsers();
-        public void AddRelation(int userId, int courseId);
-        public void DeleteRelation (int userId, int courseId);
-        public void CreateUser(User user);
+        void AddRelation(int userId, int courseId);
+        void DeleteRelation (int userId, int courseId);
+        void CreateUser(User user);
 
         ICollection<User> userList { get; }
-        int loggedInUserId { get; set; }
-        Role? loggedInUserRole { get; set; }
-        public int currentCourseId { get; set; }
+        int LoggedInUserId { get; set; }
+        Role? LoggedInUserRole { get; set; }
+        int CurrentCourseId { get; set; }
     }
 }

--- a/TeamWebApplication/Models/User.cs
+++ b/TeamWebApplication/Models/User.cs
@@ -32,11 +32,6 @@ namespace TeamWebApplication.Models
         }
 
         public int CompareTo(User? other)
-        {//User su esamu User, ids; td sort ICollection - tik realizacija, var list.. add sort
-            throw new NotImplementedException();
-        }
-
-        public int CompareTo(User? other)
         {
             if (UserId > other.UserId || other == null)
                 return 1;

--- a/TeamWebApplication/TextData/PostData.txt
+++ b/TeamWebApplication/TextData/PostData.txt
@@ -1,4 +1,4 @@
-30025
+30026
 30000;10000;Introduction;2023-09-18 19:27:40;True;Text;This is a placeholder
 30001;10000;Unit 1;2023-09-18 20:27:40;False;Text;This is an another placeholder
 30002;10002;Knowledge;2023-09-18 18:27:40;True;Text;This is once more a placeholder
@@ -14,3 +14,4 @@
 30022;10004;Introduction;2023-10-09 00:04:47;True;Text;Welcome to the course!
 30023;10008;Introduction;2023-10-09 00:05:18;True;Text;Welcome to the course!
 30024;10008;Unit 1;2023-10-09 00:06:26;True;Link;https://www.youtube.com/watch?v=wxznTygnRfQ
+30025;10004;Unit 1;2023-10-11 14:03:24;True;Text;Read the news


### PR DESCRIPTION
…face members are implicitly public and do not require explicit access modifiers.

Once again fixed names as C# naming conventions require...